### PR TITLE
Fixed mis-named method

### DIFF
--- a/lib/coda_docs/client/controls.rb
+++ b/lib/coda_docs/client/controls.rb
@@ -6,7 +6,7 @@ module CodaDocs
         response.parsed_response['items']
       end
 
-      def formula(doc_id, control_id, options = {})
+      def control(doc_id, control_id, options = {})
         self.class.get("/docs/#{doc_id}/controls/#{control_id}", query: options)
       end
     end


### PR DESCRIPTION
The method 'control' had the name 'formula'. Probably a copy/paste error.