### PR TITLE
Specify doc folder

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,9 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec
+
+# To open up gem in pry mode during development
+# Run rake console
+task :console do
+  exec "pry -r coda_docs -I ./lib"
+end

--- a/lib/coda_docs/client/docs.rb
+++ b/lib/coda_docs/client/docs.rb
@@ -10,12 +10,14 @@ module CodaDocs
         self.class.get("/docs/#{doc_id}", query: options)
       end
 
-      def create_doc(title = 'Untitled', source_doc = nil)
+      def create_doc(title: 'Untitled', timezone: 'America/Los_Angeles', source: nil, folder_id: nil)
         self.class.post(
           '/docs',
           body: {
-            'title' => title,
-            'sourceDoc' => source_doc
+            title: title,
+            sourceDoc: source,
+            timezone: timezone,
+            folderId: folder_id
           }.to_json
         )
       end


### PR DESCRIPTION
To allow for specifying of folder id when creating a new doc. This addresses issue #12.

*PS:* This might cause breaking changes as `create_doc` now takes keyword parameters, but I think that's a better way to go since the method arguments are more than 2.

